### PR TITLE
Fix nullpointer exception when changing config in-game and returning

### DIFF
--- a/BiomeTitlesUI.cs
+++ b/BiomeTitlesUI.cs
@@ -245,7 +245,10 @@ namespace BTitles
             if (Config.HideWhileBossIsAlive && bossIsAlive)
             {
                 // Hide titles if a boss is alive
-                _biomeTitle.Opacity = 0;
+                if (_biomeTitle != null)
+                {
+                    _biomeTitle.Opacity = 0;
+                }
 
                 if (_biomeSubTitle != null)
                 {
@@ -255,7 +258,10 @@ namespace BTitles
             else if (Config.HideWhileInventoryOpen && Main.playerInventory)
             {
                 // Hide titles if the inventory is open
-                _biomeTitle.Opacity = 0;
+                if (_biomeTitle != null)
+                {
+                    _biomeTitle.Opacity = 0;
+                }
 
                 if (_biomeSubTitle != null)
                 {


### PR DESCRIPTION
When changing the mod config (specifically the position) while being in-game (I mean actively playing in a session) there’s a null-pointer exception

![image](https://github.com/audaki/BTitles-1.4.3/assets/1321285/1349f5d2-eae9-4635-86ac-7460ea086764)

This pull request should fix the issue. At least this specific null pointer exception.